### PR TITLE
Use root logger in Public API if setup_logging() hasn't been called

### DIFF
--- a/docs/source/example_ltas_public.ipynb
+++ b/docs/source/example_ltas_public.ipynb
@@ -11,10 +11,17 @@
    },
    "outputs": [],
    "source": [
-    "# Executing this cell will disable all TQDM outputs in stdout.\n",
+    "# Executing this cell will:\n",
+    "\n",
+    "# Disable all TQDM outputs in stdout.\n",
     "import os\n",
     "\n",
-    "os.environ[\"DISABLE_TQDM\"] = \"True\""
+    "os.environ[\"DISABLE_TQDM\"] = \"True\"\n",
+    "\n",
+    "# Setup the python logger for the Public API\n",
+    "from osekit import setup_logging\n",
+    "\n",
+    "setup_logging()  # Overwrites the default logger to"
    ]
   },
   {

--- a/docs/source/example_multiple_spectrograms_public.ipynb
+++ b/docs/source/example_multiple_spectrograms_public.ipynb
@@ -11,10 +11,17 @@
    },
    "outputs": [],
    "source": [
-    "# Executing this cell will disable all TQDM outputs in stdout.\n",
+    "# Executing this cell will:\n",
+    "\n",
+    "# Disable all TQDM outputs in stdout.\n",
     "import os\n",
     "\n",
-    "os.environ[\"DISABLE_TQDM\"] = \"True\""
+    "os.environ[\"DISABLE_TQDM\"] = \"True\"\n",
+    "\n",
+    "# Setup the python logger for the Public API\n",
+    "from osekit import setup_logging\n",
+    "\n",
+    "setup_logging()  # Overwrites the default logger to"
    ]
   },
   {

--- a/docs/source/example_reshaping_multiple_files_public.ipynb
+++ b/docs/source/example_reshaping_multiple_files_public.ipynb
@@ -2,20 +2,27 @@
  "cells": [
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "dc7ebca70b3b5da",
    "metadata": {
     "tags": [
      "remove-cell"
     ]
    },
+   "outputs": [],
    "source": [
-    "# Executing this cell will disable all TQDM outputs in stdout.\n",
+    "# Executing this cell will:\n",
+    "\n",
+    "# Disable all TQDM outputs in stdout.\n",
     "import os\n",
     "\n",
-    "os.environ[\"DISABLE_TQDM\"] = \"True\""
-   ],
-   "outputs": [],
-   "execution_count": null
+    "os.environ[\"DISABLE_TQDM\"] = \"True\"\n",
+    "\n",
+    "# Setup the python logger for the Public API\n",
+    "from osekit import setup_logging\n",
+    "\n",
+    "setup_logging()  # Overwrites the default logger to"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -35,10 +42,12 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "bb002105fc9632e8",
    "metadata": {
     "tags": []
    },
+   "outputs": [],
    "source": [
     "from pathlib import Path\n",
     "\n",
@@ -52,9 +61,7 @@
     ")\n",
     "\n",
     "dataset.build()"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -64,8 +71,10 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "a29c761d4bbd5303",
    "metadata": {},
+   "outputs": [],
    "source": [
     "print(f\"{' DATASET ':#^60}\")\n",
     "print(f\"{'Begin:':<30}{str(dataset.origin_dataset.begin):>30}\")\n",
@@ -86,9 +95,7 @@
     "        for f in dataset.origin_files\n",
     "    ],\n",
     ").set_index(\"Name\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -98,10 +105,12 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "b4c2c3857ffcb60f",
    "metadata": {
     "tags": []
    },
+   "outputs": [],
    "source": [
     "from osekit.public_api.analysis import Analysis, AnalysisType\n",
     "from pandas import Timestamp, Timedelta\n",
@@ -113,9 +122,7 @@
     "    data_duration=Timedelta(seconds=5),\n",
     "    name=\"reshape_example\",\n",
     ")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -128,19 +135,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "2f799a26d626e418",
    "metadata": {
     "tags": []
    },
+   "outputs": [],
    "source": [
     "# Returns a Core API AudioDataset that matches the analysis\n",
     "audio_dataset = dataset.get_analysis_audiodataset(analysis=analysis)\n",
     "\n",
     "# Filter the returned AudioDataset\n",
     "audio_dataset.data = [ad for ad in audio_dataset.data if not ad.is_empty]"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -150,15 +157,15 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "9b65cfdc720d50e6",
    "metadata": {
     "tags": []
    },
+   "outputs": [],
    "source": [
     "dataset.run_analysis(analysis=analysis, audio_dataset=audio_dataset)"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -168,8 +175,10 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "3cb0adbb96d2251a",
    "metadata": {},
+   "outputs": [],
    "source": [
     "pd.DataFrame(\n",
     "    [\n",
@@ -182,25 +191,23 @@
     "        for ad in dataset.get_dataset(analysis.name).data\n",
     "    ],\n",
     ").set_index(\"Exported file\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "58b7aec2d8863a02",
    "metadata": {
     "tags": [
      "remove-cell"
     ]
    },
+   "outputs": [],
    "source": [
     "# Reset the dataset to get all files back to place.\n",
     "\n",
     "dataset.reset()"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   }
  ],
  "metadata": {

--- a/src/osekit/public_api/dataset.py
+++ b/src/osekit/public_api/dataset.py
@@ -136,7 +136,11 @@ class Dataset:
             source=self.folder,
             destination=self.folder / "other",
             excluded_paths={file.path for file in ads.files}
-            | set((self.folder / "log").iterdir())
+            | set(
+                (self.folder / "log").iterdir()
+                if (self.folder / "log").exists()
+                else ()
+            )
             | {self.folder / "log"},
         )
         self._sort_dataset(ads)
@@ -146,6 +150,16 @@ class Dataset:
         self.logger.info("Build done!")
 
     def _create_logger(self) -> None:
+        if not logging.getLogger("dataset").handlers:
+            message = (
+                "Logging has not been configured. "
+                "The dataset will use the root logger. "
+                "Use osekit.setup_logging() if wanted."
+            )
+            logging.warning(message)
+            self.logger = logging.getLogger()
+            return
+
         logs_directory = self.folder / "log"
         if not logs_directory.exists():
             logs_directory.mkdir(mode=DPDEFAULT)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -7,7 +7,9 @@ import pytest
 import yaml
 
 from osekit import setup_logging
+from osekit.config import TIMESTAMP_FORMAT_EXPORTED_FILES_UNLOCALIZED
 from osekit.logging_context import LoggingContext
+from osekit.public_api.dataset import Dataset
 
 
 @pytest.fixture
@@ -156,3 +158,23 @@ def test_logging_context(caplog: pytest.fixture) -> None:
     assert caplog.records[1].message == "From context logger"
     assert caplog.records[2].name == "default_logger"
     assert caplog.records[2].message == "From default logger again"
+
+
+def test_public_api_dataset_logger(
+    audio_files: pytest.fixture, tmp_path: pytest.fixture
+) -> None:
+    dataset = Dataset(
+        folder=tmp_path,
+        strptime_format=TIMESTAMP_FORMAT_EXPORTED_FILES_UNLOCALIZED,
+    )
+
+    # Without setting the logging up, the PublicAPI should log directly to the root logger
+    dataset.build()
+    assert dataset.logger == logging.getLogger()
+    dataset.reset()
+
+    # With setting the logging up, the PublicAPI should log to the dataset's logger
+    setup_logging()
+    dataset.build()
+    assert dataset.logger != logging.getLogger()
+    assert dataset.logger.parent == logging.getLogger("dataset")

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -15,6 +15,14 @@ def setup_module_logging() -> None:
     """Set up the osekit logging."""
     setup_logging()
 
+
+@pytest.fixture(autouse=True)
+def reset_logging():
+    """Reset the python logging module."""
+    yield
+    importlib.reload(logging)
+
+
 @pytest.fixture
 def temp_user_logging_config(tmp_path: Path) -> Path:
     """Writes a yaml logging config file in tmp_path, then returns its path.
@@ -92,7 +100,11 @@ def set_user_config_env(temp_user_logging_config: Path) -> None:
 
 
 @pytest.mark.allow_log_write_to_file
-def test_user_logging_config(set_user_config_env, caplog, tmp_path: Path):
+def test_user_logging_config(
+    set_user_config_env: pytest.fixture,
+    caplog: pytest.fixture,
+    tmp_path: Path,
+) -> None:
     assert (
         len(logging.getLogger("test_user_logger").handlers) > 0
     )  # This is a tweaky way of checking if the test_user_logger logger has already been created
@@ -105,7 +117,11 @@ def test_user_logging_config(set_user_config_env, caplog, tmp_path: Path):
     assert "User debug log" in open(f"{tmp_path}/logs.log").read()
 
 
-def test_default_logging_config(setup_module_logging, caplog, tmp_path: Path):
+def test_default_logging_config(
+    setup_module_logging: pytest.fixture,
+    caplog: pytest.fixture,
+    tmp_path: Path,
+) -> None:
     assert (
         len(logging.getLogger("dataset").handlers) > 0
     )  # This is a tweaky way of checking if the test_user_logger logger has already been created
@@ -118,7 +134,7 @@ def test_default_logging_config(setup_module_logging, caplog, tmp_path: Path):
 
 
 @pytest.mark.unit
-def test_logging_context(caplog) -> None:
+def test_logging_context(caplog: pytest.fixture) -> None:
     logging_context = LoggingContext()
 
     context_logger = logging.getLogger("context_logger")

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from copy import deepcopy
 
 import numpy as np
@@ -8,6 +9,7 @@ from pandas import Timedelta, Timestamp
 from scipy.signal import ShortTimeFFT
 from scipy.signal.windows import hamming
 
+from osekit import setup_logging
 from osekit.config import (
     TIMESTAMP_FORMAT_EXPORTED_FILES_LOCALIZED,
     TIMESTAMP_FORMAT_EXPORTED_FILES_UNLOCALIZED,
@@ -1093,3 +1095,23 @@ def test_edit_analysis_before_run(
 
     # Instrument has been edited
     assert analysis_ads.instrument.end_to_end_db == new_instrument.end_to_end_db
+
+
+def test_logger(
+    audio_files: pytest.fixture, tmp_path: pytest.fixture, reset_logging: pytest.fixture
+) -> None:
+    dataset = Dataset(
+        folder=tmp_path,
+        strptime_format=TIMESTAMP_FORMAT_EXPORTED_FILES_UNLOCALIZED,
+    )
+
+    # Without setting the logging up, the PublicAPI should log directly to the root logger
+    dataset.build()
+    assert dataset.logger == logging.getLogger()
+    dataset.reset()
+
+    # With setting the logging up, the PublicAPI should log to the dataset's logger
+    setup_logging()
+    dataset.build()
+    assert dataset.logger != logging.getLogger()
+    assert dataset.logger.parent == logging.getLogger("dataset")

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from copy import deepcopy
 
 import numpy as np
@@ -9,7 +8,6 @@ from pandas import Timedelta, Timestamp
 from scipy.signal import ShortTimeFFT
 from scipy.signal.windows import hamming
 
-from osekit import setup_logging
 from osekit.config import (
     TIMESTAMP_FORMAT_EXPORTED_FILES_LOCALIZED,
     TIMESTAMP_FORMAT_EXPORTED_FILES_UNLOCALIZED,
@@ -1095,23 +1093,3 @@ def test_edit_analysis_before_run(
 
     # Instrument has been edited
     assert analysis_ads.instrument.end_to_end_db == new_instrument.end_to_end_db
-
-
-def test_logger(
-    audio_files: pytest.fixture, tmp_path: pytest.fixture, reset_logging: pytest.fixture
-) -> None:
-    dataset = Dataset(
-        folder=tmp_path,
-        strptime_format=TIMESTAMP_FORMAT_EXPORTED_FILES_UNLOCALIZED,
-    )
-
-    # Without setting the logging up, the PublicAPI should log directly to the root logger
-    dataset.build()
-    assert dataset.logger == logging.getLogger()
-    dataset.reset()
-
-    # With setting the logging up, the PublicAPI should log to the dataset's logger
-    setup_logging()
-    dataset.build()
-    assert dataset.logger != logging.getLogger()
-    assert dataset.logger.parent == logging.getLogger("dataset")


### PR DESCRIPTION
In this PR:

## Reset the logging module after each logging test

This will ensure each other test module runs on a clean setup

## Disable the custom loggers for public API datasets if `setup_logging()` hasn't been called

If so, a warning is printed in the root logger when the dataset is built or deserialized, and the root logger is used instead of the custom datasets loggers.

## TODO:

Add tests to assess the logging with/without calling `setup_logging()`